### PR TITLE
Add .d.ts for Prettier config

### DIFF
--- a/prettier/index.d.ts
+++ b/prettier/index.d.ts
@@ -1,0 +1,2 @@
+declare const _exports: import('prettier').Config;
+export = _exports;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "include": ["prettier/**/*"],
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+  }
+}


### PR DESCRIPTION
I've added the `.d.ts` for the Prettier config, mainly for the benefit of importing it in GraphQL code generator (`codegen.ts`).

It's probably not necessary to do the same for our ESLint configs, because those are meant to be consumed in `eslint.config.js` only and a quick glance at the docs does not indicate that there is a `.ts` equivalent for that.

Fixes #90 