### PR TITLE
Update stylistic rules

### DIFF
--- a/eslint/base.js
+++ b/eslint/base.js
@@ -42,6 +42,6 @@ module.exports = {
         alphabetize: {order: 'asc', caseInsensitive: true},
       },
     ],
-    'no-console': ['error', {allow: ['info', 'warn', 'error']}],
+    'no-console': ['warn', {allow: ['info', 'warn', 'error', 'debug']}],
   },
 };

--- a/eslint/base.js
+++ b/eslint/base.js
@@ -42,6 +42,7 @@ module.exports = {
         alphabetize: {order: 'asc', caseInsensitive: true},
       },
     ],
+    'arrow-body-style': ['warn', 'never'],
     'no-console': ['warn', {allow: ['info', 'warn', 'error', 'debug']}],
   },
 };

--- a/eslint/react.js
+++ b/eslint/react.js
@@ -10,7 +10,7 @@ module.exports = {
   files: ['**/*.tsx', '**/*.jsx'],
   plugins: {react: reactPlugin, 'react-hooks': reactHooksPlugin},
   settings: {
-    'react': {
+    react: {
       version: 'detect',
     },
   },
@@ -20,6 +20,9 @@ module.exports = {
     ...reactHooksPlugin.configs.recommended.rules,
     'react/prop-types': 'off',
     'react/require-default-props': 'off',
-    'react/jsx-curly-brace-presence': ['error', 'never'],
+    'react/jsx-boolean-value': 'warn',
+    'react/jsx-curly-brace-presence': ['warn', 'never'],
+    'react/jsx-no-useless-fragment': 'warn',
+    'react/self-closing-comp': 'warn',
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atmina/linting",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A collection of opinionated in-house linting rules.",
   "main": "index.js",
   "scripts": {},


### PR DESCRIPTION
Fixes #184

> Prohibit `foo={true}` on JSX tags, `foo` is enough as attribute
`/* eslint react/jsx-boolean-value: ["warn", "never"] */`

> Enforce self-closing tags instead of having expanded empty tags `<div></div>` should be `<div />`
`/* eslint react/self-closing-comp: "warn" */`

> Enforce expression bodies of arrow function `() => { return "foo"; }` should become `() => "foo"`
`/* eslint arrow-body-style: ["warn", "never] */`

> Remove unnecessary fragments: `<><div /></>` becomes `<div />`
`/* eslint react/jsx-no-useless-fragment: "warn" */`

> [ ] Trim classNames (if possible) `w-full h-12 ` (trailing space) becomes `w-full h-12`

This seems a bit tricky right now. `prettier-plugin-tailwindcss` used to have this feature but it was quickly reverted because it was trimming more than it should have.

See https://github.com/tailwindlabs/tailwindcss/discussions/7560

In lieu of other options, we would have to write our own rule. I found this (deprecated) plugin which maybe could be used for reference:
https://github.com/liferay/eslint-config-liferay/blob/master/plugins/eslint-plugin-liferay/lib/rules/trim-class-names.js

I'll make a new issue for that.

---

As we add more rules, I would like to stick to the convention that "stylistic" rules (i.e. those that do not catch bad runtime behavior) are marked as warnings instead of errors. We should still strive to have zero warnings in total and our CI usually enforces this; however, warnings are highlighted differently in IDEs and it is helpful to be able to differentiate them from "actual" errors. WDYT?
