### PR TITLE
`jsx-no-useless-fragment`: add allowExpressions: true

### DIFF
--- a/eslint/react.js
+++ b/eslint/react.js
@@ -22,7 +22,7 @@ module.exports = {
     'react/require-default-props': 'off',
     'react/jsx-boolean-value': 'warn',
     'react/jsx-curly-brace-presence': ['warn', 'never'],
-    'react/jsx-no-useless-fragment': 'warn',
+    'react/jsx-no-useless-fragment': ['warn', {allowExpressions: true}],
     'react/self-closing-comp': 'warn',
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atmina/linting",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A collection of opinionated in-house linting rules.",
   "main": "index.js",
   "scripts": {},


### PR DESCRIPTION
Relaxes the "no useless fragments" rule to permit fragments with expression bodies.

```jsx
const MyComp: FC<PropsWithChildren<Props>> = ({ children, ...props }) => {
  if (props.something) return <Something />
  return <>{children}</>;
}
```