### PR TITLE
fix(react): configure react for ts,tsx,js,jsx

### DIFF
--- a/eslint/react.js
+++ b/eslint/react.js
@@ -7,7 +7,7 @@ const {recommended, 'jsx-runtime': jsxRuntime} = reactPlugin.configs;
  * @type {import('eslint').Linter.FlatConfig}
  */
 module.exports = {
-  files: ['**/*.tsx', '**/*.jsx'],
+  files: ['**/*.{ts,tsx,js,jsx}'],
   plugins: {react: reactPlugin, 'react-hooks': reactHooksPlugin},
   settings: {
     react: {


### PR DESCRIPTION
React rules should also be enforced in `ts` and `js` Files.
Some rules only apply to Hooks and therefore do not depend on JSX. These hooks should still be checked :)

As pointed out by @mvarendorff this needs either a rollback of the typescript-eslint upgrade or needs to wait until the next.js plugin releases [their upgrade to v7](https://github.com/vercel/next.js/pull/62137).