### PR TITLE
feat: use eslint-plugin-import for import/order only

### DIFF
--- a/packages/linting/eslint/base.js
+++ b/packages/linting/eslint/base.js
@@ -8,12 +8,6 @@ const globals = require('globals');
 module.exports = {
   files: ['**/*.{ts,tsx,js,jsx}'],
   plugins: {import: importPlugin},
-  // Fix for https://github.com/import-js/eslint-plugin-import/issues/2556
-  settings: {
-    'import/parsers': {
-      espree: ['.js', '.cjs', '.mjs', '.jsx'],
-    },
-  },
   languageOptions: {
     globals: {
       ...globals.browser,
@@ -26,7 +20,6 @@ module.exports = {
   },
   rules: {
     ...eslintJs.configs.recommended.rules,
-    ...importPlugin.configs.recommended.rules,
     'import/order': [
       'warn',
       {

--- a/packages/linting/package.json
+++ b/packages/linting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atmina/linting",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "A collection of opinionated in-house linting rules.",
   "main": "index.js",
   "scripts": {},


### PR DESCRIPTION
Disables all `eslint-plugin-import` rules except for `import/order` because they are superseded by TypeScript and occasionally cause false positives, e.g. when using import aliases.

Fixes #210